### PR TITLE
fix: use correct field name for stop order's price

### DIFF
--- a/orders.go
+++ b/orders.go
@@ -58,7 +58,7 @@ type CreateOrderRequest struct {
 }
 
 type OrderStop struct {
-	PriceStop float64 `json:"price_stop"`
+	StopPrice float64 `json:"stop_price"`
 	Type      string  `json:"type"`
 }
 


### PR DESCRIPTION
Use stop order's price name as it shows in buda's API doc:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/685ff8d5-dd55-4e5a-9dce-18f0ebee02ae" />
